### PR TITLE
Change visibility of loaded gifs to default

### DIFF
--- a/inject/inject.css
+++ b/inject/inject.css
@@ -1,9 +1,5 @@
-img[src*=gif] {
+img[src*=gif]:not(.gif-delayer-loaded) {
   visibility: hidden;
-}
-
-img[src*=gif].gif-delayer-loaded {
-  visibility: visible;
 }
 
 .gif-delayer-loading {


### PR DESCRIPTION
NOT TESTED!

Only apply `visibility:hidden` to loading gifs. This makes unnecessary having to set `visibility:visible` to gifs that are already loaded, which doesn't work on gifs that were hidden by default. 
This uses the `:not()` pseudo-class which is available on both Firefox 3+ and Chrome 14+ as shown in [css-tricks.com](http://css-tricks.com/almanac/selectors/n/not/#browser-support)

Closes https://github.com/octatone/Gif-Delayer/issues/4 
