### PR TITLE
Fixed the browser making bogus requests to ./undefined

### DIFF
--- a/inject/inject.js
+++ b/inject/inject.js
@@ -43,7 +43,7 @@ function loadGif (gif) {
   var $gif = $(gif).addClass('gif-delayer');
 
   function loaded () {
-    gif.src = undefined;
+    gif.src = "";
     $loading.remove();
     $gif.addClass('gif-delayer-loaded');
     setTimeout(function () {


### PR DESCRIPTION
By setting `.src` to `undefined` the browser will append `/undefined` to the current page and make a `GET` request to that URL, expecting an image.

Setting it to `""` will prevent that request from being made.