### PR TITLE
Bugfix requests with "/undefined" at the end of URLs

### DIFF
--- a/inject/inject.js
+++ b/inject/inject.js
@@ -43,12 +43,12 @@ function loadGif (gif) {
   var $gif = $(gif).addClass('gif-delayer');
 
   function loaded () {
-    gif.src = undefined;
+    $gif.removeAttr('src');
     $loading.remove();
     $gif.addClass('gif-delayer-loaded');
     setTimeout(function () {
       // hack to force starting from the beginning
-      gif.src = url;
+      $gif.attr('src', url);
     }, 0);
   }
 


### PR DESCRIPTION
Some time ago I started search and analyze the cause of requests to my servers with "/undefined" at the end of urls.

In summary I understood that main reason is in plugin Gif Delayer.

Very important to fix it, because this bug affects many sites, and I think not only me tried to find origin of such requests, and spent a lot of time, had assuming that cause somewhere in own code.