### PR TITLE
Prevent crash when gif's parent is null.

### DIFF
--- a/inject/inject.js
+++ b/inject/inject.js
@@ -82,12 +82,14 @@ function loadGif (gif) {
   function loaded () {
     // hack to force starting from the beginning
     var parent = gif.parentNode;
-    parent.removeChild(gif);
+    if (parent) {
+      parent.removeChild(gif);
+      setTimeout(function () {
+        parent.appendChild(gif);
+      }, 0);
+    }
     $loading.remove();
     $gif.addClass('gif-delayer-loaded');
-    setTimeout(function () {
-      parent.appendChild(gif);
-    }, 0);
   }
 
   if (!_loadedURLS[url] && !_loadingURLS[url]) {


### PR DESCRIPTION
Ran into this issue when using leaflet.js in Chrome.

![image](https://cloud.githubusercontent.com/assets/558242/17072349/65f34256-501c-11e6-92ec-088c22c684d4.png)
